### PR TITLE
Fix YouTube 403 errors by enabling yt-dlp remote components

### DIFF
--- a/video_downloader.py
+++ b/video_downloader.py
@@ -20,7 +20,7 @@ class VideoDownloader:
     def _get_info(self):
         """Fetch metadata (description, title, etc.) without downloading the video."""
         logger.debug(f"Fetching video info for: {self.url}")
-        ydl_opts = {"quiet": True, "no_warnings": True, "skip_download": True}
+        ydl_opts = {"quiet": True, "no_warnings": True, "skip_download": True, "remote_components": ["ejs:github"]}
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ydl.extract_info(self.url, download=False)
         self.video_id = info.get("id")
@@ -43,6 +43,7 @@ class VideoDownloader:
                 "outtmpl": video_path,
                 "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
                 "merge_output_format": "mp4",
+                "remote_components": ["ejs:github"],
             }
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([self.url])


### PR DESCRIPTION
## Summary
- YouTube now requires solving JavaScript challenges (the "n parameter" challenge) before allowing video downloads
- Without the challenge solver, yt-dlp fails with `HTTP Error 403: Forbidden` during the download step
- Adds `remote_components: ["ejs:github"]` to yt-dlp options in both `_get_info()` and `_download_video()`, allowing yt-dlp to download the official JS challenge solver from [yt-dlp/ejs](https://github.com/yt-dlp/ejs)

## Context
YouTube has been increasingly enforcing JS challenges to gate video downloads. The `remote_components` option was introduced in recent yt-dlp versions to handle this. See [yt-dlp/yt-dlp#12482](https://github.com/yt-dlp/yt-dlp/issues/12482) and the [yt-dlp EJS wiki](https://github.com/yt-dlp/yt-dlp/wiki/EJS) for background.

## Test plan
- [x] Verified fix resolves 403 error on YouTube URLs (tested with a long-form video)
- [x] Confirmed yt-dlp successfully downloads the challenge solver script and completes video download
- [ ] Test with TikTok and Instagram URLs to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)